### PR TITLE
Update 9.snapshots.md - 

### DIFF
--- a/px-minio/9.snapshots.md
+++ b/px-minio/9.snapshots.md
@@ -8,7 +8,7 @@ clear && PX_POD=$(kubectl get pods -l name=portworx -n kube-system -o jsonpath='
 kubectl exec -it $PX_POD -n kube-system -- \
     /opt/pwx/bin/pxctl cred create   --provider s3   \
     --s3-access-key myaccesskey   --s3-secret-key mysecretkey   \
-    --s3-region us-east-1 --s3-endpoint http://$MINIO_ENDPOINT
+    --s3-region us-east-1 --s3-endpoint http://$MINIO_ENDPOINT my_creds
 ```{{execute T1}}
 
 One the credentials are setup you can take a backup of the Minio PVC using STORK. Take a look at the YAML: ```cat px-snap.yaml```{{execute T1}} and then kubectl apply it to take the cloud snapshot.


### PR DESCRIPTION
pxctl now requires a <name> and this Katacoda did not have the required name