### PR TITLE
Update px-postgres-pvc.yaml

### DIFF
--- a/px-k8s-postgres-all-in-one/assets/px-postgres-pvc.yaml
+++ b/px-k8s-postgres-all-in-one/assets/px-postgres-pvc.yaml
@@ -2,9 +2,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
    name: px-postgres-pvc
-   annotations:
-     volume.beta.kubernetes.io/storage-class: px-repl3-sc
 spec:
+   storageClassName: px-repl3-sc
    accessModes:
      - ReadWriteOnce
    resources:


### PR DESCRIPTION
We should follow the standard for defining storageClassName as part of the spec instead of the annotation.