### PR TITLE
Update ssh-node01.sh

### DIFF
--- a/portworx-lighthouse/ssh-node01.sh
+++ b/portworx-lighthouse/ssh-node01.sh
@@ -1,4 +1,2 @@
-ssh -o strictHostKeyChecking=no node01 "mkdir /root/.kube"; scp /root/.kube/config node01:/root/.kube/config;
-clear
-ssh -o strictHostKeyChecking=no node01 ;
-clear
+ssh -o strictHostKeyChecking=no node01 "mkdir /root/.kube" && scp /root/.kube/config node01:/root/.kube/config && ssh -o strictHostKeyChecking=no node01 && clear
+


### PR DESCRIPTION
When the katacoda scenario is slow to load, the scp takes time and the ssh to node01 is not working. 
Lighthouse is installed on node01 and not master.