### PR TITLE
reviewed and fixed issues

### DIFF
--- a/portworx-k8-sched-snap/step2-verify.sh
+++ b/portworx-k8-sched-snap/step2-verify.sh
@@ -1,4 +1,4 @@
-if [[ `kubectl describe  schedulepolicy  daily-schedule -n mysql-app | grep -i "10:00"` ]]
+if [[ `kubectl get  schedulepolicy  daily-schedule -n mysql-app -o json  | jq -r ".policy.daily.time" | grep -w 10:00PM` ]] && [[ `kubectl get  schedulepolicy  daily-schedule -n mysql-app -o json  | jq -r ".policy.daily.retain" | grep -w 5` ]]
 then
 	echo "done"
 fi

--- a/portworx-security-roles-contexts/create-roles.sh
+++ b/portworx-security-roles-contexts/create-roles.sh
@@ -1,4 +1,4 @@
-scp -o StrictHostKeyChecking=no /tmp/role.json node01:/root
+scp -o StrictHostKeyChecking=no /root/role.json node01:/root
 scp -o StrictHostKeyChecking=no /tmp/role-update.json node01:/tmp
 scp -o StrictHostKeyChecking=no /tmp/developer.json node01:/tmp
 kubectl delete ds kube-keepalived-vip -n kube-system

--- a/portworx-troubleshooting/assets/load-quiz.sh
+++ b/portworx-troubleshooting/assets/load-quiz.sh
@@ -6,6 +6,7 @@ launch.sh
 sh /tmp/create-pxkeys.sh
 
 cp /tmp/px-spec.yaml /root/px-spec.yaml
+scp -o StrictHostKeyChecking=no /tmp/*.yaml node01:/tmp
 
 kubectl delete ds kube-keepalived-vip -n kube-system
 

--- a/portworx-volume-placement/assets/load-quiz.sh
+++ b/portworx-volume-placement/assets/load-quiz.sh
@@ -9,8 +9,8 @@ kubectl cp -n kube-system $STORK_POD:/storkctl/linux/storkctl ./storkctl
 sudo mv storkctl /usr/local/bin &&
 sudo chmod +x /usr/local/bin/storkctl
 
-kubectl delete ds kube-keepalived-vip -n kube-system
+#kubectl delete ds kube-keepalived-vip -n kube-system
 
-kubectl create -f /tmp/create-mysql.yaml
+#kubectl create -f /tmp/create-mysql.yaml
 
-kubectl create -f /tmp/sched-pol.yaml
+#kubectl create -f /tmp/sched-pol.yaml


### PR DESCRIPTION
The four issues specifically mentioned have been fixed and tested in the published scenarios. 


The only cases where we copy files to node01/host02 are:
portworx-security-authentication
portworx-security-roles-contexts
portworx-security-tokens-contexts
portworx-troubleshooting

With the changes introduced by katacoda the only workaround for these that I could find is to scp from the master node to node01 in the background scripts. I believe the only place where the files were missing was the troubleshooting lab (authconfig not copied) and portworx-security-roles (I had fixed this earlier but the roles.json was getting copied to /tmp not /root). 

Both these have been fixed. 