### PR TITLE
Px demo env

### DIFF
--- a/environments/px-demo-26-cluster-running/katacoda.yaml
+++ b/environments/px-demo-26-cluster-running/katacoda.yaml
@@ -1,0 +1,1 @@
+base: 'kubernetes-cluster-running:1.18'

--- a/environments/px-demo-26-cluster-running/katacoda.yaml
+++ b/environments/px-demo-26-cluster-running/katacoda.yaml
@@ -1,1 +1,1 @@
-base: 'kubernetes-cluster-running:1.18'
+base: 'kubernetes-cluster-running:1.20'

--- a/environments/px-demo-26-cluster-running/master/build/1_px-init.sh
+++ b/environments/px-demo-26-cluster-running/master/build/1_px-init.sh
@@ -1,0 +1,7 @@
+cat << EOF > /opt/configure-environment.sh
+#!/bin/bash
+curl -L -s -o px-spec.yaml "http://install.portworx.com/26'?mc=false&kbVer=v1.18.0&b=true&s=%2Fdev%2Fvdb&c=px-demo&stork=true&st=k8s" && \
+kubectl apply -f px-spec.yaml
+EOF
+
+chmod +x /opt/configure-environment.sh

--- a/environments/px-demo-26-cluster-running/master/katacoda.yaml
+++ b/environments/px-demo-26-cluster-running/master/katacoda.yaml
@@ -1,1 +1,1 @@
-base: 'kubernetes-master-ubuntu1804-1-18'
+base: 'kubernetes-master-ubuntu2004-1-20'

--- a/environments/px-demo-26-cluster-running/master/katacoda.yaml
+++ b/environments/px-demo-26-cluster-running/master/katacoda.yaml
@@ -1,0 +1,1 @@
+base: 'kubernetes-master-ubuntu1804-1-18'

--- a/environments/px-demo-26-cluster-running/node/build/1_init.sh
+++ b/environments/px-demo-26-cluster-running/node/build/1_init.sh
@@ -1,0 +1,1 @@
+echo "Nothing to change"

--- a/environments/px-demo-26-cluster-running/node/katacoda.yaml
+++ b/environments/px-demo-26-cluster-running/node/katacoda.yaml
@@ -1,0 +1,1 @@
+base: 'kubernetes-node-ubuntu1804-1-18'

--- a/environments/px-demo-26-cluster-running/node/katacoda.yaml
+++ b/environments/px-demo-26-cluster-running/node/katacoda.yaml
@@ -1,1 +1,1 @@
-base: 'kubernetes-node-ubuntu1804-1-18'
+base: 'kubernetes-node-ubuntu2004-1-20'


### PR DESCRIPTION
This PR adds an environments folder for building a custom portworx 2.6 px-demo environment suitable for use in scenarios as "portworx-px-demo-26-cluster-running"

https://www.katacoda.community/custom-environment.html

Managing this as a custom environment gives the portworx team greater visibility into how the build differs from other kubernetes builds and control over changes.

The custom image will build on the Katacoda beta server where it could be reviewed as a 2-node cluster.  O'Reilly media will need to add some custom handling to make it a 4 node cluster with an appropriate health check, cpu, and memory configuration.

When ready to start that work, open a new support ticket with them.
