### PR TITLE
Update Portworx and Kubernetes to 2.6.3 and 1.18 versions respectively

### DIFF
--- a/px-k8s-vol-basic/assets/px-repl3-sc.yaml
+++ b/px-k8s-vol-basic/assets/px-repl3-sc.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
     name: px-repl3-sc
 provisioner: kubernetes.io/portworx-volume

--- a/px-k8s-vol-basic/index.json
+++ b/px-k8s-vol-basic/index.json
@@ -45,6 +45,6 @@
         "uimessage1": "\u001b[32mYour Interactive Bash Terminal.\u001b[m\r\n"
     },
     "backend": {
-        "imageid": "portworx-kubernetes-running"
+        "imageid": "portworx-kubernetes-running:1.18"
     }
 }

--- a/px-k8s-vol-basic/px-sc.md
+++ b/px-k8s-vol-basic/px-sc.md
@@ -10,7 +10,7 @@ For example, the following is a Portworx StorageClass whose volumes have replica
 
 ```yaml
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
     name: px-repl3-sc
 provisioner: kubernetes.io/portworx-volume


### PR DESCRIPTION
Update Portworx and Kubernetes to 2.6.3 and 1.18 versions respectively